### PR TITLE
Fixed typos

### DIFF
--- a/docs/Vitis_intro-1.md
+++ b/docs/Vitis_intro-1.md
@@ -100,7 +100,7 @@ After completing Introduction to Vitis Part 1 and 2, you will learn to:
 
     ![](./images/Vitis_intro/add_host_sources.png)
 
-1. In the *Import Sources* window, click *Browse* and navigate to `~/xup_compute_acceleration/sources/vadd_lab/` and click **OK**. Then select the **vadd.cpp, xcl2.cpp, and xcl2.cpp** files as they will be executed on the host. Finally click *Finish*
+1. In the *Import Sources* window, click *Browse* and navigate to `~/xup_compute_acceleration/sources/vadd_lab/` and click **OK**. Then select the **vadd.cpp, xcl2.cpp, and xcl2.hpp** files as they will be executed on the host. Finally click *Finish*
 
     ![](./images/Vitis_intro/import_sources.png)
 
@@ -142,7 +142,6 @@ After completing Introduction to Vitis Part 1 and 2, you will learn to:
 
 1. Select the **Launch SW Emulator** option and click **OK**
 
-    ![](./images/vitis_intro/run_as.png)
 
 1. Observe the application has run and the output is displayed in the *Console* view
 

--- a/docs/Vitis_intro-2.md
+++ b/docs/Vitis_intro-2.md
@@ -65,7 +65,7 @@ This lab is a continuation of previous *Introduction to Vitis* lab. You ended th
 
     ![](images/Vitis_intro/hw_emu_krnl_profile_settings.png)
 
-1. Build the project by selecting **vadd_system"" in `Assistant` view and clicking the build button. This may take about 10 minutes
+1. Build the project by selecting *vadd\_system* in `Assistant` view and clicking the build button. This may take about 10 minutes
 
 1. Run Hardware Emulation in GUI mode
 


### PR DESCRIPTION
There were couple of typos which Hugo caught during the past tutorial, so I corrected them. I have removed reference to one png file (hw_emu_run.png) since the GUI presented are different depending on Windows Explorer -> Run button vs Assistant -> Run button. I can remove it if you want me to or you can remove OR leave it there.